### PR TITLE
Remove ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES

### DIFF
--- a/SpoolDays.xcodeproj/project.pbxproj
+++ b/SpoolDays.xcodeproj/project.pbxproj
@@ -615,7 +615,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A213BC18E4CC71A416C5B370 /* Pods-SpoolDays.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = SpoolDays/SpoolDays.entitlements;
@@ -643,7 +642,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8569C3C3CB9BF32A4499F2DD /* Pods-SpoolDays.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = SpoolDays/SpoolDays.entitlements;


### PR DESCRIPTION
Fix below warning on `pod install`

```
[!] The `SpoolDays [Debug]` target overrides the `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` build setting defined in `Pods/Target Support Files/Pods-SpoolDays/Pods-SpoolDays.debug.xcconfig'. This can lead to problems with the CocoaPods installation
    - Use the `$(inherited)` flag, or
    - Remove the build settings from the target.

[!] The `SpoolDays [Release]` target overrides the `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` build setting defined in `Pods/Target Support Files/Pods-SpoolDays/Pods-SpoolDays.release.xcconfig'. This can lead to problems with the CocoaPods installation
    - Use the `$(inherited)` flag, or
    - Remove the build settings from the target.
```