### PR TITLE
Fix deprecated keys in Info.plist

### DIFF
--- a/SpoolDays/Info.plist
+++ b/SpoolDays/Info.plist
@@ -16,8 +16,6 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/SpoolDays/Info.plist
+++ b/SpoolDays/Info.plist
@@ -44,7 +44,7 @@
 	</dict>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
-		<string>armv7</string>
+		<string>arm64</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>


### PR DESCRIPTION
## Summary
- Remove the obsolete `CFBundleSignature` key (a macOS-era Creator Code, deprecated since iOS 8)
- Change `UIRequiredDeviceCapabilities` from `armv7` (32-bit devices) to `arm64`, avoiding potential App Store Connect rejection

## Test plan
- [x] `plutil -lint SpoolDays/Info.plist` passes
- [x] `mise run build` succeeds for iOS Simulator