### PR TITLE
Call super.viewDidAppear(_:) in EditViewController

### DIFF
--- a/SpoolDays/EditViewController.swift
+++ b/SpoolDays/EditViewController.swift
@@ -45,6 +45,7 @@ class EditViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
 
     override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         focusOnTextField()
     }
 


### PR DESCRIPTION
## Summary
- `EditViewController.viewDidAppear(_:)` was missing the required `super.viewDidAppear(animated)` call
- Apple's documentation requires calling super in this lifecycle method; omitting it can break view controller containment, accessibility, and transition animations

## Test plan
- [x] `mise run build` succeeds for iOS Simulator