### PR TITLE
Replace (indexPath as NSIndexPath).row with indexPath.row

### DIFF
--- a/SpoolDays/DatesViewModel.swift
+++ b/SpoolDays/DatesViewModel.swift
@@ -10,7 +10,7 @@ class DatesViewModel: NSObject {
     }
 
     func deleteDate(_ indexPath: IndexPath) {
-        dates[(indexPath as NSIndexPath).row].delete()
+        dates[indexPath.row].delete()
         fetch()
     }
 

--- a/SpoolDays/EditViewController.swift
+++ b/SpoolDays/EditViewController.swift
@@ -148,7 +148,7 @@ class EditViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if (indexPath as NSIndexPath).row == 0 {
+        if indexPath.row == 0 {
             let cell = TextFieldTableViewCell(
                 value: dateViewModel.baseDate?.title ?? "",
                 placeHolder: I18n.title,
@@ -165,7 +165,7 @@ class EditViewController: UIViewController, UITableViewDelegate, UITableViewData
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        if (indexPath as NSIndexPath).row == 0 {
+        if indexPath.row == 0 {
             focusOnTextField()
         } else {
             blurOnTextField()

--- a/SpoolDays/HistoryTableViewController.swift
+++ b/SpoolDays/HistoryTableViewController.swift
@@ -51,7 +51,7 @@ class HistoryTableViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let log = historyViewModel.logs[(indexPath as NSIndexPath).row]
+        let log = historyViewModel.logs[indexPath.row]
         let cell = HistoryTableViewCell(log: log)
         cell.textLabel?.text = log.dateString()
         cell.detailTextLabel?.text = log.eventString()
@@ -67,7 +67,7 @@ class HistoryTableViewController: UITableViewController {
     fileprivate func deleteLog(_ indexPath: IndexPath) {
         if tableView.cellForRow(at: indexPath) is HistoryTableViewCell {
             PopupAlertView.confirm(self, message: I18n.areYouSureYouWantToDelete) {
-                self.historyViewModel.deleteLog((indexPath as NSIndexPath).row)
+                self.historyViewModel.deleteLog(indexPath.row)
                 self.tableView.deleteRows(at: [indexPath], with: .fade)
             }
         }

--- a/SpoolDays/MainViewController.swift
+++ b/SpoolDays/MainViewController.swift
@@ -92,7 +92,7 @@ class MainViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let dateViewModel = DateViewModel(baseDate: datesViewModel.dates[(indexPath as NSIndexPath).row])
+        let dateViewModel = DateViewModel(baseDate: datesViewModel.dates[indexPath.row])
         return DateTableViewCell(reuseIdentifier: "Cell", dateViewModel: dateViewModel)
     }
 
@@ -116,7 +116,7 @@ class MainViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to toIndexPath: IndexPath) {
-        datesViewModel.move(fromIndex: (fromIndexPath as NSIndexPath).row, toIndex: (toIndexPath as NSIndexPath).row)
+        datesViewModel.move(fromIndex: fromIndexPath.row, toIndex: toIndexPath.row)
     }
 
     fileprivate func resetDate(_ cell: DateTableViewCell) {


### PR DESCRIPTION
## Summary
- `IndexPath` has had a native `.row` property since Swift 3, so bridging to `NSIndexPath` is unnecessary
- Simplified the pattern in `DatesViewModel.swift`, `MainViewController.swift`, `EditViewController.swift`, and `HistoryTableViewController.swift`

## Test plan
- [x] `mise run build` succeeds for iOS Simulator