### PR TITLE
Remove empty AppDelegate/SceneDelegate lifecycle methods

### DIFF
--- a/SpoolDays/AppDelegate.swift
+++ b/SpoolDays/AppDelegate.swift
@@ -92,18 +92,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
 
-    func applicationWillResignActive(_ application: UIApplication) {
-    }
-
-    func applicationDidEnterBackground(_ application: UIApplication) {
-    }
-
-    func applicationWillEnterForeground(_ application: UIApplication) {
-    }
-
-    func applicationDidBecomeActive(_ application: UIApplication) {
-    }
-
     func applicationWillTerminate(_ application: UIApplication) {
         CoreDataManager.shared.save()
     }

--- a/SpoolDays/SceneDelegate.swift
+++ b/SpoolDays/SceneDelegate.swift
@@ -14,17 +14,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.makeKeyAndVisible()
     }
 
-    func sceneDidDisconnect(_ scene: UIScene) {
-    }
-
     func sceneDidBecomeActive(_ scene: UIScene) {
         (UIApplication.shared.delegate as? AppDelegate)?.updateBadge({ _ in return })
-    }
-
-    func sceneWillResignActive(_ scene: UIScene) {
-    }
-
-    func sceneWillEnterForeground(_ scene: UIScene) {
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {


### PR DESCRIPTION
## Summary
- Remove `applicationWillResignActive`, `applicationDidEnterBackground`, `applicationWillEnterForeground`, and `applicationDidBecomeActive` from `AppDelegate.swift` — leftover Xcode template stubs that are never called since the app uses SceneDelegate
- Remove `sceneDidDisconnect`, `sceneWillResignActive`, and `sceneWillEnterForeground` from `SceneDelegate.swift` — same reason, empty stubs with no behavior

## Test plan
- [x] `mise run build` succeeds for iOS Simulator