### PR TITLE
Remove duplicate saveAndWait() in favor of save()

### DIFF
--- a/SpoolDays/CoreDataManager.swift
+++ b/SpoolDays/CoreDataManager.swift
@@ -46,18 +46,6 @@ class CoreDataManager {
         }
     }
 
-    func saveAndWait() {
-        let context = persistentContainer.viewContext
-
-        if context.hasChanges {
-            do {
-                try context.save()
-            } catch {
-                print("Save error: \(error)")
-            }
-        }
-    }
-
     func rollback() {
         context.rollback()
     }

--- a/SpoolDays/HistoryViewModel.swift
+++ b/SpoolDays/HistoryViewModel.swift
@@ -12,7 +12,7 @@ class HistoryViewModel: NSObject {
     }
 
     func save() {
-        CoreDataManager.shared.saveAndWait()
+        CoreDataManager.shared.save()
     }
 
     func deleteLog(_ index: Int) {

--- a/SpoolDays/Models/BaseDate.swift
+++ b/SpoolDays/Models/BaseDate.swift
@@ -35,7 +35,7 @@ class BaseDate: NSManagedObject {
         log.baseDate = baseDate
         log.event = "create"
 
-        CoreDataManager.shared.saveAndWait()
+        CoreDataManager.shared.save()
         return baseDate
     }
 
@@ -53,7 +53,7 @@ class BaseDate: NSManagedObject {
         self.title = title
         self.date = date
 
-        CoreDataManager.shared.saveAndWait()
+        CoreDataManager.shared.save()
     }
 
     class func move(fromIndex: Int, toIndex: Int) {
@@ -75,7 +75,7 @@ class BaseDate: NSManagedObject {
                 dates[i].sort = NSNumber(value: dates[i].sort.intValue + 1)
             }
         }
-        CoreDataManager.shared.saveAndWait()
+        CoreDataManager.shared.save()
     }
 
     func delete() {
@@ -87,7 +87,7 @@ class BaseDate: NSManagedObject {
             }
         }
         context.delete(self)
-        CoreDataManager.shared.saveAndWait()
+        CoreDataManager.shared.save()
     }
 
     func reset(_ date: Date) {
@@ -100,7 +100,7 @@ class BaseDate: NSManagedObject {
         log.event = "reset"
 
         self.date = date
-        CoreDataManager.shared.saveAndWait()
+        CoreDataManager.shared.save()
     }
 
     class func first() -> BaseDate? {


### PR DESCRIPTION
## Summary
- `CoreDataManager.saveAndWait()` was byte-for-byte identical to `save()`; removed it and updated all callers to use `save()` instead
- Updated call sites in `BaseDate.swift` (5 occurrences) and `HistoryViewModel.swift` (1 occurrence)

## Test plan
- [x] `mise run build` succeeds for iOS Simulator
- [x] `mise run test` passes (4/4 tests)