### PR TITLE
Switch to closure-based NotificationCenter observer and simplify reload()

### DIFF
--- a/SpoolDays/MainViewController.swift
+++ b/SpoolDays/MainViewController.swift
@@ -39,22 +39,18 @@ class MainViewController: UITableViewController {
             observer.invalidate()
         }
         observers.removeAll()
-        NotificationCenter.default.removeObserver(self)
     }
 
     fileprivate func addNotificationCenterObserver() {
-        NotificationCenter.default.addObserver(self, selector: #selector(UIApplicationDelegate.applicationDidBecomeActive(_:)), name: NSNotification.Name.NSExtensionHostDidBecomeActive, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(reload), name: .didSaveOrDeleteDate, object: nil)
-    }
-
-    @objc fileprivate func reload() {
-        DispatchQueue.global(qos: .userInteractive).async { [weak self] in
-            DispatchQueue.main.async {
-                if let self = self {
-                    self.datesViewModel.fetch()
-                }
+        NotificationCenter.default.addObserver(forName: .didSaveOrDeleteDate, object: nil, queue: .main) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.reload()
             }
         }
+    }
+
+    fileprivate func reload() {
+        datesViewModel.fetch()
     }
 
     func loadEditButton() {


### PR DESCRIPTION
## Summary
- Remove the dead `NSExtensionHostDidBecomeActive` observer — an App Extension notification that never fires in the main app
- Switch the remaining `.didSaveOrDeleteDate` observer to the closure-based `addObserver(forName:object:queue:using:)` API, which removes the need for `removeObserver(self)` in `deinit`
- Simplify `reload()`: it hopped to a background queue only to immediately jump back to main, doing no actual background work. Since `fetch()` touches Core Data's `viewContext` and must run on main anyway, the pointless GCD hop and the `@objc` annotation (only needed for the old selector-based observer) are both removed

## Test plan
- [x] `mise run build` succeeds for iOS Simulator with no warnings
- [x] `mise run test` passes (4/4 tests)