### PR TITLE
Remove unnecessary UserDefaults.synchronize() call

### DIFF
--- a/SpoolDays/GroupData.swift
+++ b/SpoolDays/GroupData.swift
@@ -12,6 +12,5 @@ class GroupData {
         }
         let sharedDefaults = UserDefaults(suiteName: userDefaultSuiteName)
         sharedDefaults?.set(list, forKey: keyOfDates)
-        sharedDefaults?.synchronize()
     }
 }


### PR DESCRIPTION
## Summary
- Remove `sharedDefaults?.synchronize()` in `GroupData.setDates(_:)`
- `synchronize()` has been unnecessary since iOS 12; the system persists changes automatically, and Apple's documentation explicitly deprecates the call

## Test plan
- [x] `mise run build` succeeds for iOS Simulator