### PR TITLE
Use shorthand member syntax for UIBarButtonItem constants

### DIFF
--- a/SpoolDays/EditViewController.swift
+++ b/SpoolDays/EditViewController.swift
@@ -68,7 +68,7 @@ class EditViewController: UIViewController, UITableViewDelegate, UITableViewData
     // MARK: cancel button
 
     func loadCancelButton() {
-        let cancelButton = UIBarButtonItem(title: I18n.cancel, style: UIBarButtonItem.Style.plain, target: self, action: #selector(EditViewController.cancelButtonTapped))
+        let cancelButton = UIBarButtonItem(title: I18n.cancel, style: .plain, target: self, action: #selector(EditViewController.cancelButtonTapped))
         navigationItem.leftBarButtonItem = cancelButton
     }
 
@@ -79,7 +79,7 @@ class EditViewController: UIViewController, UITableViewDelegate, UITableViewData
     // MARK: save button
 
     func loadSaveButton() {
-        let saveButton = UIBarButtonItem(title: I18n.save, style: UIBarButtonItem.Style.plain, target: self, action: #selector(EditViewController.saveButtonTapped))
+        let saveButton = UIBarButtonItem(title: I18n.save, style: .plain, target: self, action: #selector(EditViewController.saveButtonTapped))
         navigationItem.rightBarButtonItem = saveButton
     }
 

--- a/SpoolDays/HistoryTableViewController.swift
+++ b/SpoolDays/HistoryTableViewController.swift
@@ -26,7 +26,7 @@ class HistoryTableViewController: UITableViewController {
     // MARK: cancel button
 
     func loadCancelButton() {
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: I18n.cancel, style: UIBarButtonItem.Style.plain, target: self, action: #selector(HistoryTableViewController.cancelButtonTapped))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: I18n.cancel, style: .plain, target: self, action: #selector(HistoryTableViewController.cancelButtonTapped))
     }
 
     @objc func cancelButtonTapped() {
@@ -36,7 +36,7 @@ class HistoryTableViewController: UITableViewController {
     // MARK: save button
 
     func loadSaveButton() {
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: I18n.save, style: UIBarButtonItem.Style.plain, target: self, action: #selector(HistoryTableViewController.saveButtonTapped))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: I18n.save, style: .plain, target: self, action: #selector(HistoryTableViewController.saveButtonTapped))
     }
 
     @objc func saveButtonTapped() {

--- a/SpoolDays/MainViewController.swift
+++ b/SpoolDays/MainViewController.swift
@@ -72,7 +72,7 @@ class MainViewController: UITableViewController {
         let button = UIButton(configuration: config)
         button.addTarget(self, action: #selector(MainViewController.addButtonTapped), for: .touchUpInside)
         let addButton = UIBarButtonItem(customView: button)
-        let spacer = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.flexibleSpace, target: nil, action: nil)
+        let spacer = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         toolbarItems = [spacer, addButton]
     }
 


### PR DESCRIPTION
## Summary
- Replace `UIBarButtonItem.Style.plain` with `.plain` in `EditViewController.swift` (2 occurrences) and `HistoryTableViewController.swift` (2 occurrences)
- Replace `UIBarButtonItem.SystemItem.flexibleSpace` with `.flexibleSpace` in `MainViewController.swift`
- Swift already infers the enclosing type at these call sites, so the fully qualified prefixes are redundant

## Test plan
- [x] `mise run build` succeeds for iOS Simulator