### PR TITLE
Use .normal instead of UIControl.State() for button state

### DIFF
--- a/SpoolDays/DateTableViewCell.swift
+++ b/SpoolDays/DateTableViewCell.swift
@@ -32,8 +32,8 @@ class DateTableViewCell: UITableViewCell {
     fileprivate func loadButtons() {
         let resetButton = UIButton(type: .custom)
         resetButton.backgroundColor = ThemeColor.resetColor()
-        resetButton.setTitle(I18n.reset, for: UIControl.State())
-        resetButton.setTitleColor(UIColor.white, for: UIControl.State())
+        resetButton.setTitle(I18n.reset, for: .normal)
+        resetButton.setTitleColor(.white, for: .normal)
         resetButton.titleLabel?.adjustsFontSizeToFitWidth = true
     }
 }

--- a/SpoolDays/EditViewController.swift
+++ b/SpoolDays/EditViewController.swift
@@ -187,8 +187,8 @@ class EditViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
         let deleteButton = UIButton(frame: CGRect(x: 0, y: cellHeight * CGFloat(cellCount + 1), width: view.bounds.width, height: cellHeight))
         deleteButton.backgroundColor = ThemeColor.deleteColor()
-        deleteButton.setTitle(I18n.delete, for: UIControl.State())
-        deleteButton.setTitleColor(UIColor.white, for: UIControl.State())
+        deleteButton.setTitle(I18n.delete, for: .normal)
+        deleteButton.setTitleColor(.white, for: .normal)
         view.addSubview(deleteButton)
 
         deleteButton.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
## Summary
- Replace `UIControl.State()` with `.normal` in `DateTableViewCell.swift` (2 occurrences) and `EditViewController.swift` (2 occurrences)
- `UIControl.State()` constructs the default state via its empty option set initializer; `.normal` expresses the same intent directly

## Test plan
- [x] `mise run build` succeeds for iOS Simulator