### PR TITLE
Convert ThemeColor from an NSObject subclass to a caseless enum

### DIFF
--- a/SpoolDays/ThemeColor.swift
+++ b/SpoolDays/ThemeColor.swift
@@ -1,24 +1,24 @@
 import Foundation
 import UIKit
 
-class ThemeColor: NSObject {
-    class func baseColor() -> UIColor {
+enum ThemeColor {
+    static func baseColor() -> UIColor {
         return colorByRGB(red: 0, green: 195, blue: 121, alpha: 255)
     }
 
-    class func baseTextColor() -> UIColor {
+    static func baseTextColor() -> UIColor {
         return colorByRGB(red: 238, green: 238, blue: 238, alpha: 255)
     }
 
-    class func resetColor() -> UIColor {
+    static func resetColor() -> UIColor {
         return colorByRGB(red: 18, green: 191, blue: 41, alpha: 255)
     }
 
-    class func deleteColor() -> UIColor {
+    static func deleteColor() -> UIColor {
         return colorByRGB(red: 211, green: 56, blue: 28, alpha: 255)
     }
 
-    fileprivate class func colorByRGB(red: Int, green: Int, blue: Int, alpha: Int) -> UIColor {
+    fileprivate static func colorByRGB(red: Int, green: Int, blue: Int, alpha: Int) -> UIColor {
         return UIColor(red: (CGFloat(red) / 255.0), green: CGFloat(green) / 255.0, blue: CGFloat(blue) / 255.0, alpha: CGFloat(alpha) / 255.0)
     }
 }


### PR DESCRIPTION
## Summary
- Change `ThemeColor` from `class ThemeColor: NSObject` to `enum ThemeColor` (caseless)
- `ThemeColor` only exposes static color factory methods and never needs instantiation or Objective-C runtime features, so the `NSObject` inheritance wasn't warranted
- A caseless enum makes accidental instantiation impossible at compile time
- Converted `class func` to `static func` throughout, since enums don't support `class func`

## Test plan
- [x] `mise run build` succeeds for iOS Simulator
- [x] `mise run test` passes (4/4 tests)