### PR TITLE
Use Any instead of AnyObject in GroupData.setDates

### DIFF
--- a/SpoolDays/GroupData.swift
+++ b/SpoolDays/GroupData.swift
@@ -7,8 +7,8 @@ class GroupData {
     class func setDates(_ dates: [BaseDate]) {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
-        let list = dates.map { baseDate -> [String: AnyObject] in
-            return ["title": baseDate.title as AnyObject, "date": dateFormatter.string(from: baseDate.date as Date) as AnyObject]
+        let list = dates.map { baseDate -> [String: Any] in
+            return ["title": baseDate.title, "date": dateFormatter.string(from: baseDate.date)]
         }
         let sharedDefaults = UserDefaults(suiteName: userDefaultSuiteName)
         sharedDefaults?.set(list, forKey: keyOfDates)


### PR DESCRIPTION
## Summary
- Change the dictionary type in `GroupData.setDates(_:)` from `[String: AnyObject]` to `[String: Any]`
- `AnyObject` bridges specifically to Objective-C class types, which isn't needed here since the values are Swift value types (`String`)
- Drop the redundant `as AnyObject` casts and the `as Date` cast on `baseDate.date`, which is already `Date`

## Test plan
- [x] `mise run build` succeeds for iOS Simulator