### PR TITLE
Cache DateFormatter instances instead of creating them per call

### DIFF
--- a/SpoolDays/DateExtension.swift
+++ b/SpoolDays/DateExtension.swift
@@ -11,17 +11,26 @@ extension Date {
         return components.day ?? 0
     }
 
+    private static let shortDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .none
+        formatter.dateStyle = .short
+        return formatter
+    }()
+
+    private static let isoDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
     func dateString(locale: Locale = .current) -> String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.timeStyle = .none
-        dateFormatter.dateStyle = .short
-        dateFormatter.locale = locale
-        return dateFormatter.string(from: self)
+        let formatter = Date.shortDateFormatter
+        formatter.locale = locale
+        return formatter.string(from: self)
     }
 
     static func fromString(_ str: String) -> Date? {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        return dateFormatter.date(from: str)
+        return isoDateFormatter.date(from: str)
     }
 }

--- a/SpoolDays/GroupData.swift
+++ b/SpoolDays/GroupData.swift
@@ -4,9 +4,13 @@ class GroupData {
     class var userDefaultSuiteName: String { return "group.org.codefirst.SpoolDaysExtension" }
     class var keyOfDates: String { return "dates" }
 
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
     class func setDates(_ dates: [BaseDate]) {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
         let list = dates.map { baseDate -> [String: Any] in
             return ["title": baseDate.title, "date": dateFormatter.string(from: baseDate.date)]
         }


### PR DESCRIPTION
## Summary
- `DateFormatter` initialization is expensive; Apple recommends reusing instances rather than creating them repeatedly
- `Date.dateString(locale:)` and `Date.fromString(_:)` now use cached static `DateFormatter` instances instead of allocating a new one on every call
- `GroupData.setDates(_:)` caches its `DateFormatter` the same way

## Test plan
- [x] `mise run build` succeeds for iOS Simulator
- [x] `mise run test` passes (4/4 tests)