### PR TITLE
Tighten access control on internal-only properties

### DIFF
--- a/SpoolDays/CoreDataManager.swift
+++ b/SpoolDays/CoreDataManager.swift
@@ -5,7 +5,7 @@ class CoreDataManager {
     nonisolated(unsafe) static let shared = CoreDataManager()
 
     private init() {}
-    lazy var applicationDocumentsDirectory: URL = {
+    private lazy var applicationDocumentsDirectory: URL = {
         let urls = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
         let applicationSupportURL = urls[urls.count - 1]
         let applicationName = Bundle.main.infoDictionary?[kCFBundleNameKey as String] as? String ?? "SpoolDays"
@@ -16,7 +16,7 @@ class CoreDataManager {
         return appDirectoryURL
     }()
 
-    lazy var persistentContainer: NSPersistentContainer = {
+    private lazy var persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: "Model")
         let storeURL = self.applicationDocumentsDirectory.appendingPathComponent("spooldays.sqlite3")
         let description = NSPersistentStoreDescription(url: storeURL)

--- a/SpoolDays/DatesViewModel.swift
+++ b/SpoolDays/DatesViewModel.swift
@@ -2,7 +2,7 @@ import CoreData
 import Foundation
 
 class DatesViewModel: NSObject {
-    @objc dynamic var dates: [BaseDate] = []
+    @objc private(set) dynamic var dates: [BaseDate] = []
 
     func fetch() {
         dates = CoreDataManager.shared.fetchBaseDates()

--- a/SpoolDays/HistoryViewModel.swift
+++ b/SpoolDays/HistoryViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 class HistoryViewModel: NSObject {
-    dynamic var logs = [Log]()
+    private(set) dynamic var logs = [Log]()
     let baseDate: BaseDate
     init(baseDate: BaseDate) {
         self.baseDate = baseDate


### PR DESCRIPTION
## Summary
- `CoreDataManager.applicationDocumentsDirectory` and `.persistentContainer` are only referenced within `CoreDataManager` itself, so mark both `private`
- `DatesViewModel.dates` and `HistoryViewModel.logs` are only ever mutated from within their owning view models; external call sites only read them (including KVO observation for `dates`), so mark both `private(set)`

## Test plan
- [x] `mise run build` succeeds for iOS Simulator
- [x] `mise run test` passes (4/4 tests)