### PR TITLE
Add mise setup to e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,6 +20,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      - uses: jdx/mise-action@v4.2.3
+        env:
+          MISE_DISABLE_TOOLS: ruby
+
       - name: Use Node.js
         uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
The `Build for Simulator` step failed with:

```
error: mise command not found. Install mise (https://mise.jdx.dev/installing-mise.html) and try again.
```

The `Run Script (LicensePlist)` build phase in `SpoolDays.xcodeproj` requires `mise`, but `jdx/mise-action` was set up only in `ci.yml` and `deploy.yml`, not in `e2e.yml`.

Failing run: https://github.com/suer/spool-days/actions/runs/30673662966

🤖 Generated with [Claude Code](https://claude.com/claude-code)